### PR TITLE
Split() replaced with SplitN()

### DIFF
--- a/gprops.go
+++ b/gprops.go
@@ -72,7 +72,7 @@ func (props *Properties) Load(r io.Reader) error {
 	for scanner.Scan() {
 		line := scanner.Text()
 		if !strings.HasPrefix(line, commentPrefix) && len(line) > 0 {
-			keyValuePair := strings.Split(line, settingSeparator)
+			keyValuePair := strings.SplitN(line, settingSeparator, 2)
 			if len(keyValuePair) == 2 {
 				props.Set(strings.TrimSpace(keyValuePair[0]), strings.TrimSpace(keyValuePair[1]))
 			} else {

--- a/gprops.go
+++ b/gprops.go
@@ -92,7 +92,7 @@ func (props *Properties) Load(r io.Reader) error {
 // You can add comment, which will be stored as first line beginning with '#'.
 func (props *Properties) Store(w io.Writer, comment string) error {
 	bw := bufio.NewWriter(w)
-	defer bw.Flush()
+	//defer bw.Flush()
 
 	if comment != "" {
 		bw.WriteString(commentPrefix + " " + comment + "\n")
@@ -102,6 +102,10 @@ func (props *Properties) Store(w io.Writer, comment string) error {
 		if err != nil {
 			return err
 		}
+	}
+	err := bw.Flush()
+	if err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
minor change to fix the issue when a value in properties file contains delimiter e.g.
separator = ==
in that case current version throws the error "incorrect syntax in config file."
